### PR TITLE
feat: refine server navigation and support

### DIFF
--- a/tgbot/keyboards/inline_buy.py
+++ b/tgbot/keyboards/inline_buy.py
@@ -1,0 +1,59 @@
+# - *- coding: utf-8 - *-
+"""Inline keyboards for buying virtual currency."""
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from math import ceil
+
+from tgbot.utils.const_functions import ikb
+
+SERVERS = [f"Сервер {i}" for i in range(1, 90)]
+PER_PAGE = 24
+TOTAL_PAGES = ceil(len(SERVERS) / PER_PAGE)
+
+
+def servers_kb(page: int = 0) -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    start = page * PER_PAGE
+    end = min(start + PER_PAGE, len(SERVERS))
+    for idx, server in enumerate(SERVERS[start:end], start=start):
+        builder.button(text=server, callback_data=f"server_select:{idx}")
+    builder.adjust(3)
+
+    nav = []
+    if page > 0:
+        nav.append(ikb("⬅️", data=f"servers_page:{page-1}"))
+    nav.append(ikb(f"{page + 1}/{TOTAL_PAGES}", data="ignore"))
+    if end < len(SERVERS):
+        nav.append(ikb("➡️", data=f"servers_page:{page+1}"))
+    builder.row(*nav)
+    builder.row(ikb("🔙 В меню", data="back_to_menu"))
+    return builder.as_markup()
+
+
+def back_menu_kb(back: str) -> InlineKeyboardMarkup:
+    """Keyboard with back and menu buttons."""
+    builder = InlineKeyboardBuilder()
+    builder.row(ikb("⬅️ Назад", data=back))
+    builder.row(ikb("🔙 В меню", data="back_to_menu"))
+    return builder.as_markup()
+
+
+def payment_methods_kb() -> InlineKeyboardMarkup:
+    builder = InlineKeyboardBuilder()
+    builder.row(InlineKeyboardButton(text="Оплатить Telegram Stars", pay=True))
+    builder.row(ikb("Cryptobot", data="pay_method:cryptobot"))
+    builder.row(ikb("ЮMoney", data="pay_method:yoomoney"))
+    builder.row(ikb("⬅️ Назад", data="buy_back_account"))
+    builder.row(ikb("🔙 В меню", data="back_to_menu"))
+    return builder.as_markup()
+
+
+def payment_bill_kb(link: str, receipt: str, method: str) -> InlineKeyboardMarkup:
+    """Keyboard with link and check button for generated invoices."""
+    builder = InlineKeyboardBuilder()
+    builder.row(ikb("🌀 Перейти к оплате", url=link))
+    builder.row(ikb("🔄 Проверить оплату", data=f"BuyPay:{method}:{receipt}"))
+    builder.row(ikb("⬅️ Назад", data="buy_back_methods"))
+    builder.row(ikb("🔙 В меню", data="back_to_menu"))
+    return builder.as_markup()

--- a/tgbot/keyboards/inline_main_menu.py
+++ b/tgbot/keyboards/inline_main_menu.py
@@ -1,0 +1,16 @@
+# - *- coding: utf-8 - *-
+"""Inline keyboards for main user menu."""
+from aiogram.types import InlineKeyboardMarkup
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from tgbot.utils.const_functions import ikb
+
+
+def start_menu_finl() -> InlineKeyboardMarkup:
+    """Keyboard shown to regular users on /start."""
+    keyboard = InlineKeyboardBuilder()
+    keyboard.row(ikb("Купить вирты", data="buy_start"))
+    keyboard.row(ikb("Мои покупки", data="user_purchases"))
+    keyboard.row(ikb("Отзывы", data="reviews_start"))
+    keyboard.row(ikb("Поддержка", data="support_start"))
+    return keyboard.as_markup()

--- a/tgbot/keyboards/reply_main.py
+++ b/tgbot/keyboards/reply_main.py
@@ -11,14 +11,12 @@ def menu_frep(user_id: int) -> ReplyKeyboardMarkup:
     keyboard = ReplyKeyboardBuilder()
 
     keyboard.row(
-        rkb("🎁 Купить"),
-    ).row(
         rkb("👤 Профиль"), rkb("☎️ Поддержка"),
     )
 
     if user_id in get_admins():
         keyboard.row(
-            rkb("🎁 Управление товарами"), rkb("📊 Статистика"),
+            rkb("📊 Статистика"),
         ).row(
             rkb("⚙️ Настройки"), rkb("🔆 Общие функции"), rkb("🔑 Платежные системы"),
         )
@@ -32,6 +30,8 @@ def payments_frep() -> ReplyKeyboardMarkup:
 
     keyboard.row(
         rkb("🔷 CryptoBot"), rkb("🔮 ЮMoney"),
+    ).row(
+        rkb("⭐️ Telegram Stars"),
     ).row(
         rkb("🔙 Главное меню"),
     )
@@ -60,21 +60,6 @@ def settings_frep() -> ReplyKeyboardMarkup:
         rkb("🖍 Изменить данные"), rkb("🕹 Выключатели"),
     ).row(
         rkb("🔙 Главное меню"),
-    )
-
-    return keyboard.as_markup(resize_keyboard=True)
-
-
-# Кнопки изменения товаров
-def items_frep() -> ReplyKeyboardMarkup:
-    keyboard = ReplyKeyboardBuilder()
-
-    keyboard.row(
-        rkb("📁 Создать позицию ➕"), rkb("🗃 Создать категорию ➕"),
-    ).row(
-        rkb("📁 Изменить позицию 🖍"), rkb("🗃 Изменить категорию 🖍"),
-    ).row(
-        rkb("🔙 Главное меню"), rkb("🎁 Добавить товары ➕"), rkb("❌ Удаление"),
     )
 
     return keyboard.as_markup(resize_keyboard=True)

--- a/tgbot/routers/__init__.py
+++ b/tgbot/routers/__init__.py
@@ -3,7 +3,7 @@ from aiogram import Dispatcher, F
 
 from tgbot.routers import main_errors, main_start, main_missed
 from tgbot.routers.admin import admin_menu, admin_functions, admin_payment, admin_products, admin_settings
-from tgbot.routers.user import user_menu, user_transactions, user_products
+from tgbot.routers.user import user_menu, user_transactions, user_products, buy_virts, support_chat
 from tgbot.utils.misc.bot_filters import IsAdmin
 
 
@@ -28,6 +28,8 @@ def register_all_routers(dp: Dispatcher):
     dp.include_router(admin_menu.router)  # Админ роутер
     dp.include_router(user_products.router)  # Юзер роутер
     dp.include_router(user_transactions.router)  # Юзер роутер
+    dp.include_router(buy_virts.router)  # Покупка виртов
+    dp.include_router(support_chat.router)  # Чат поддержки и отзывы
     dp.include_router(admin_functions.router)  # Админ роутер
     dp.include_router(admin_payment.router)  # Админ роутер
     dp.include_router(admin_settings.router)  # Админ роутер

--- a/tgbot/routers/admin/admin_menu.py
+++ b/tgbot/routers/admin/admin_menu.py
@@ -8,7 +8,7 @@ from aiogram.types import Message, FSInputFile
 from aiogram.utils.media_group import MediaGroupBuilder
 
 from tgbot.data.config import PATH_LOGS, PATH_DATABASE
-from tgbot.keyboards.reply_main import payments_frep, settings_frep, functions_frep, items_frep
+from tgbot.keyboards.reply_main import payments_frep, settings_frep, functions_frep
 from tgbot.utils.const_functions import get_date
 from tgbot.utils.misc.bot_models import FSM, ARS
 from tgbot.utils.misc_functions import get_statistics
@@ -46,17 +46,6 @@ async def admin_functions(message: Message, bot: Bot, state: FSM, arSession: ARS
     await message.answer(
         "<b>🔆 Общие функции бота</b>",
         reply_markup=functions_frep(),
-    )
-
-
-# Управление товарами
-@router.message(F.text == "🎁 Управление товарами")
-async def admin_products(message: Message, bot: Bot, state: FSM, arSession: ARS):
-    await state.clear()
-
-    await message.answer(
-        "<b>🎁 Редактирование товаров</b>",
-        reply_markup=items_frep(),
     )
 
 

--- a/tgbot/routers/admin/admin_payment.py
+++ b/tgbot/routers/admin/admin_payment.py
@@ -35,6 +35,16 @@ async def payment_yoomoney_open(message: Message, bot: Bot, state: FSM, arSessio
     )
 
 
+# Информация - Telegram Stars
+@router.message(F.text == "⭐️ Telegram Stars")
+async def payment_stars_open(message: Message, bot: Bot, state: FSM, arSession: ARS):
+    await state.clear()
+    await message.answer(
+        "<b>⭐️ Telegram Stars</b>\nОплата через звезды не требует настройки.",
+        reply_markup=close_finl(),
+    )
+
+
 ################################################################################
 ################################### CRYPTOBOT ##################################
 # Баланс - CryptoBot

--- a/tgbot/routers/main_start.py
+++ b/tgbot/routers/main_start.py
@@ -7,6 +7,8 @@ from tgbot.database import Settingsx, Positionx, Categoryx
 from tgbot.keyboards.inline_user import user_support_finl
 from tgbot.keyboards.inline_user_page import prod_item_position_swipe_fp
 from tgbot.keyboards.reply_main import menu_frep
+from tgbot.keyboards.inline_main_menu import start_menu_finl
+from tgbot.data.config import get_admins
 from tgbot.utils.const_functions import ded
 from tgbot.utils.misc.bot_filters import IsBuy, IsRefill, IsWork
 from tgbot.utils.misc.bot_models import FSM, ARS
@@ -63,7 +65,6 @@ async def filter_work_callback(call: CallbackQuery, bot: Bot, state: FSM, arSess
 ################################################################################
 ################################# СТАТУС ПОКУПОК ###############################
 # Фильтр на доступность покупок - сообщение
-@router.message(IsBuy(), F.text == "🎁 Купить")
 @router.message(IsBuy(), StateFilter('here_item_count'))
 async def filter_buy_message(message: Message, bot: Bot, state: FSM, arSession: ARS):
     await state.clear()
@@ -102,17 +103,28 @@ async def filter_refill_callback(call: CallbackQuery, bot: Bot, state: FSM, arSe
 # Открытие главного меню
 @router.message(F.text.in_(('🔙 Главное меню', '/start')))
 async def main_start(message: Message, bot: Bot, state: FSM, arSession: ARS):
+    """Send main menu. Admins receive their keyboard and user inline menu."""
     await state.clear()
 
-    await message.answer(
-        ded("""
-            *🐻 Lebowski Store*
-            *🔸 Если не появилось меню*
-            *🔸 Введите /start*
-        """),
-        reply_markup=menu_frep(message.from_user.id),
-        parse_mode="MarkdownV2"
-    )
+    if message.from_user.id in get_admins():
+        await message.answer(
+            ded("""
+                *🐻 Lebowski Store*
+                *🔸 Если не появилось меню*
+                *🔸 Введите /start*
+            """),
+            reply_markup=menu_frep(message.from_user.id),
+            parse_mode="MarkdownV2"
+        )
+        await message.answer(
+            "<b>Добро пожаловать! Выберите действие:</b>",
+            reply_markup=start_menu_finl(),
+        )
+    else:
+        await message.answer(
+            "<b>Добро пожаловать! Выберите действие:</b>",
+            reply_markup=start_menu_finl(),
+        )
 
 
 
@@ -138,3 +150,25 @@ async def main_start_deeplink(message: Message, bot: Bot, state: FSM, arSession:
                 f"<b>🎁 Текущая категория: <code>{get_category.category_name}</code></b>",
                 reply_markup=prod_item_position_swipe_fp(0, category_id),
             )
+
+
+# Возврат в главное меню через колбэк
+@router.callback_query(F.data == "back_to_menu")
+async def back_to_menu(call: CallbackQuery, bot: Bot, state: FSM, arSession: ARS):
+    await state.clear()
+    await call.message.delete()
+
+    if call.from_user.id in get_admins():
+        await call.message.answer(
+            ded("""
+                *🐻 Lebowski Store*
+                *🔸 Если не появилось меню*
+                *🔸 Введите /start*
+            """),
+            reply_markup=menu_frep(call.from_user.id),
+            parse_mode="MarkdownV2",
+        )
+    await call.message.answer(
+        "<b>Добро пожаловать! Выберите действие:</b>",
+        reply_markup=start_menu_finl(),
+    )

--- a/tgbot/routers/user/buy_virts.py
+++ b/tgbot/routers/user/buy_virts.py
@@ -1,0 +1,279 @@
+# - *- coding: utf-8 - *-
+"""Flow for buying virtual currency with multiple payment methods."""
+from math import ceil
+
+from aiogram import Router, F, Bot
+from aiogram.filters import StateFilter
+from aiogram.types import CallbackQuery, Message, LabeledPrice
+
+from tgbot.data.config import get_admins
+from tgbot.keyboards.inline_buy import (
+    SERVERS,
+    TOTAL_PAGES,
+    back_menu_kb,
+    payment_methods_kb,
+    payment_bill_kb,
+    servers_kb,
+)
+from tgbot.services.api_cryptobot import CryptobotAPI
+from tgbot.services.api_yoomoney import YoomoneyAPI
+from tgbot.utils.misc.bot_models import FSM, ARS
+
+router = Router(name=__name__)
+
+
+def parse_amount(text: str) -> int:
+    """Parse amount strings like 1.5кк, 500к or 1500000."""
+    t = text.lower().replace(" ", "")
+    if "кк" in t or "kk" in t:
+        num = t.replace("кк", "").replace("kk", "").replace(",", ".")
+        return int(float(num) * 1_000_000)
+    if "к" in t or "k" in t:
+        num = t.replace("к", "").replace("k", "").replace(",", ".")
+        return int(float(num) * 1_000)
+    digits = "".join(ch for ch in t if ch.isdigit())
+    return int(digits) if digits else 0
+
+
+@router.callback_query(F.data == "buy_start")
+async def buy_start(call: CallbackQuery, state: FSM):
+    await state.set_state("buy_server")
+    await call.message.edit_text(
+        f"<b>Выберите сервер (Страница 1/{TOTAL_PAGES}):</b>",
+        reply_markup=servers_kb(0),
+    )
+
+
+@router.callback_query(F.data.startswith("servers_page:"), StateFilter("buy_server"))
+async def servers_page(call: CallbackQuery, state: FSM):
+    page = int(call.data.split(":")[1])
+    await call.message.edit_text(
+        f"<b>Выберите сервер (Страница {page+1}/{TOTAL_PAGES}):</b>",
+        reply_markup=servers_kb(page),
+    )
+    await call.answer()
+
+
+@router.callback_query(F.data.startswith("server_select:"), StateFilter("buy_server"))
+async def server_selected(call: CallbackQuery, state: FSM):
+    idx = int(call.data.split(":")[1])
+    server = SERVERS[idx]
+    await state.update_data(server=server)
+    await state.set_state("buy_amount")
+    await call.message.edit_text(
+        f"<b>Сервер {server}</b>\nВведите количество валюты (например 1кк):",
+        reply_markup=back_menu_kb("buy_start"),
+    )
+    await call.answer()
+
+
+@router.callback_query(F.data == "ignore")
+async def ignore_cb(call: CallbackQuery):
+    await call.answer()
+
+
+@router.message(StateFilter("buy_amount"))
+async def amount_input(message: Message, state: FSM):
+    amount = parse_amount(message.text)
+    if amount < 500_000:
+        await message.answer(
+            "Минимальная сумма покупки 0.5кк (500000). Попробуйте снова:",
+            reply_markup=back_menu_kb("buy_start"),
+        )
+        return
+    price = ceil(amount / 1_000_000 * 99)
+    await state.update_data(amount=amount, price=price)
+    await state.set_state("buy_account")
+    await message.answer(
+        "Введите ваш банковский счет:",
+        reply_markup=back_menu_kb("buy_back_amount"),
+    )
+
+
+@router.message(StateFilter("buy_account"))
+async def account_input(message: Message, state: FSM, bot: Bot):
+    if not message.text.isdigit() or len(message.text) > 7:
+        await message.answer(
+            "Счет должен содержать только цифры и быть не длиннее 7 знаков. Введите снова:",
+            reply_markup=back_menu_kb("buy_back_amount"),
+        )
+        return
+    account = message.text
+    data = await state.get_data()
+    server = data["server"]
+    amount = data["amount"]
+    price = data["price"]
+    await state.update_data(account=account)
+    stars = ceil(price / 1.4)
+    await bot.send_invoice(
+        chat_id=message.chat.id,
+        title="Покупка виртов",
+        description=(
+            f"Сервер: {server}\n"
+            f"Количество: {amount}\n"
+            f"Цена: {price} ₽\n"
+            f"Счет: {account}"
+        ),
+        payload="buy_virts",
+        provider_token="",
+        currency="XTR",
+        prices=[LabeledPrice(label="Вирты", amount=stars)],
+        reply_markup=payment_methods_kb(),
+    )
+    await state.set_state("buy_wait_payment")
+
+
+@router.callback_query(F.data.startswith("pay_method:"), StateFilter("buy_wait_payment"))
+async def payment_choose(call: CallbackQuery, state: FSM, bot: Bot, arSession: ARS):
+    """Generate invoice for selected payment method."""
+    method = call.data.split(":")[1]
+    data = await state.get_data()
+    price = data["price"]
+    if method == "cryptobot":
+        bill_message, bill_link, bill_receipt = await CryptobotAPI(
+            bot=bot,
+            arSession=arSession,
+            update=call,
+        ).bill(price)
+        if bill_message:
+            await state.update_data(pay_method="cryptobot", bill_receipt=bill_receipt)
+            await call.message.edit_text(
+                bill_message,
+                reply_markup=payment_bill_kb(bill_link, bill_receipt, "Cryptobot"),
+            )
+            await state.set_state("buy_wait_payment")
+        else:
+            await call.message.answer("Не удалось сгенерировать платёж. Попробуйте позже.")
+    else:
+        bill_message, bill_link, bill_receipt = await YoomoneyAPI(
+            bot=bot,
+            arSession=arSession,
+            update=call,
+        ).bill(price)
+        if bill_message:
+            await state.update_data(pay_method="yoomoney", bill_receipt=bill_receipt)
+            await call.message.edit_text(
+                bill_message,
+                reply_markup=payment_bill_kb(bill_link, bill_receipt, "Yoomoney"),
+            )
+            await state.set_state("buy_wait_payment")
+        else:
+            await call.message.answer("Не удалось сгенерировать платёж. Попробуйте позже.")
+    await call.answer()
+
+
+@router.callback_query(F.data == "buy_back_account", StateFilter("buy_wait_payment"))
+async def buy_back_account(call: CallbackQuery, state: FSM):
+    await state.set_state("buy_account")
+    await call.message.delete()
+    await call.message.answer(
+        "Введите ваш банковский счет:",
+        reply_markup=back_menu_kb("buy_back_amount"),
+    )
+    await call.answer()
+
+
+@router.callback_query(F.data == "buy_back_methods", StateFilter("buy_wait_payment"))
+async def buy_back_methods(call: CallbackQuery, state: FSM, bot: Bot):
+    data = await state.get_data()
+    server, amount, price, account = (
+        data["server"],
+        data["amount"],
+        data["price"],
+        data["account"],
+    )
+    stars = ceil(price / 1.4)
+    await call.message.delete()
+    await bot.send_invoice(
+        chat_id=call.from_user.id,
+        title="Покупка виртов",
+        description=(
+            f"Сервер: {server}\n"
+            f"Количество: {amount}\n"
+            f"Цена: {price} ₽\n"
+            f"Счет: {account}"
+        ),
+        payload="buy_virts",
+        provider_token="",
+        currency="XTR",
+        prices=[LabeledPrice(label="Вирты", amount=stars)],
+        reply_markup=payment_methods_kb(),
+    )
+    await state.set_state("buy_wait_payment")
+    await call.answer()
+
+
+@router.callback_query(F.data == "buy_back_amount", StateFilter("buy_account"))
+async def buy_back_amount(call: CallbackQuery, state: FSM):
+    await state.set_state("buy_amount")
+    await call.message.edit_text(
+        "Введите количество валюты (например 1кк):",
+        reply_markup=back_menu_kb("buy_start"),
+    )
+    await call.answer()
+
+
+@router.callback_query(F.data.startswith("BuyPay:Cryptobot"), StateFilter("buy_wait_payment"))
+async def check_cryptobot(call: CallbackQuery, state: FSM, bot: Bot, arSession: ARS):
+    receipt = call.data.split(":")[2]
+    pay_status, _ = await CryptobotAPI(
+        bot=bot,
+        arSession=arSession,
+        update=call,
+    ).bill_check(receipt)
+    if pay_status == 0:
+        data = await state.get_data()
+        server, amount, account = data["server"], data["amount"], data["account"]
+        await call.message.edit_text("Ура! Ваш заказ принят, ожидайте вирты в течении 10 минут.")
+        for admin in get_admins():
+            await bot.send_message(
+                admin,
+                f"Новый заказ\nСервер: {server}\nКол-во: {amount}\nСчёт: {account}\nОплата: CryptoBot",
+            )
+        await state.clear()
+    elif pay_status == 2:
+        await call.answer("Оплата не найдена. Попробуйте позже.", True)
+    elif pay_status == 3:
+        await call.answer("Вы не успели оплатить счёт.", True)
+    else:
+        await call.answer("Не удалось проверить оплату.", True)
+
+
+@router.callback_query(F.data.startswith("BuyPay:Yoomoney"), StateFilter("buy_wait_payment"))
+async def check_yoomoney(call: CallbackQuery, state: FSM, bot: Bot, arSession: ARS):
+    receipt = call.data.split(":")[2]
+    pay_status, _ = await YoomoneyAPI(
+        bot=bot,
+        arSession=arSession,
+        update=call,
+    ).bill_check(receipt)
+    if pay_status == 0:
+        data = await state.get_data()
+        server, amount, account = data["server"], data["amount"], data["account"]
+        await call.message.edit_text("Ура! Ваш заказ принят, ожидайте вирты в течении 10 минут.")
+        for admin in get_admins():
+            await bot.send_message(
+                admin,
+                f"Новый заказ\nСервер: {server}\nКол-во: {amount}\nСчёт: {account}\nОплата: YooMoney",
+            )
+        await state.clear()
+    elif pay_status == 2:
+        await call.answer("Оплата не найдена. Попробуйте позже.", True)
+    elif pay_status == 3:
+        await call.answer("Оплата произведена не в рублях.", True)
+    else:
+        await call.answer("Не удалось проверить оплату.", True)
+
+
+@router.message(F.successful_payment, StateFilter("buy_wait_payment"))
+async def stars_success(message: Message, state: FSM, bot: Bot):
+    data = await state.get_data()
+    server, amount, account = data["server"], data["amount"], data["account"]
+    await message.answer("Ура! Ваш заказ принят, ожидайте вирты в течении 10 минут.")
+    for admin in get_admins():
+        await bot.send_message(
+            admin,
+            f"Новый заказ\nСервер: {server}\nКол-во: {amount}\nСчёт: {account}\nОплата: Telegram Stars",
+        )
+    await state.clear()
+

--- a/tgbot/routers/user/support_chat.py
+++ b/tgbot/routers/user/support_chat.py
@@ -1,0 +1,106 @@
+# - *- coding: utf-8 - *-
+"""Simple support chat between user and admins."""
+from aiogram import Router, F, Bot
+from aiogram.filters import StateFilter
+from aiogram.types import CallbackQuery, Message
+from aiogram.utils.keyboard import InlineKeyboardBuilder
+
+from tgbot.data.config import get_admins
+from tgbot.keyboards.inline_main_menu import start_menu_finl
+from tgbot.utils.const_functions import ikb
+from tgbot.utils.misc.bot_models import FSM
+
+router = Router(name=__name__)
+
+
+@router.callback_query(F.data == 'support_start')
+async def support_start(call: CallbackQuery, state: FSM):
+    await state.set_state('support_chat')
+    kb = InlineKeyboardBuilder()
+    kb.row(ikb('❌ Завершить', data='support_stop'))
+    kb.row(ikb('🔙 В меню', data='back_to_menu'))
+    await call.message.edit_text(
+        'Опишите вашу проблему, администратор свяжется с вами здесь.',
+        reply_markup=kb.as_markup(),
+    )
+
+
+@router.message(StateFilter('support_chat'))
+async def support_message(message: Message, state: FSM, bot: Bot):
+    """Send user message to admins with reply and close buttons."""
+    admin_kb = InlineKeyboardBuilder()
+    admin_kb.row(ikb('Ответить', data=f'support_reply:{message.from_user.id}'))
+    admin_kb.row(ikb('Завершить', data=f'support_close:{message.from_user.id}'))
+    for admin in get_admins():
+        await bot.send_message(
+            admin,
+            f'Пользователь {message.from_user.id} написал:\n{message.text}',
+            reply_markup=admin_kb.as_markup(),
+        )
+    user_kb = InlineKeyboardBuilder()
+    user_kb.row(ikb('❌ Завершить', data='support_stop'))
+    user_kb.row(ikb('🔙 В меню', data='back_to_menu'))
+    await message.answer(
+        'Сообщение отправлено. Ожидайте ответа администратора.',
+        reply_markup=user_kb.as_markup(),
+    )
+
+
+@router.callback_query(F.data.startswith('support_reply:'), F.from_user.id.in_(get_admins()))
+async def support_reply_call(call: CallbackQuery, state: FSM):
+    user_id = int(call.data.split(':')[1])
+    await state.update_data(reply_to=user_id)
+    await state.set_state('support_admin_reply')
+    kb = InlineKeyboardBuilder()
+    kb.row(ikb('❌ Отмена', data='support_cancel'))
+    await call.message.answer(f'Введите ответ для пользователя {user_id}.', reply_markup=kb.as_markup())
+    await call.answer()
+
+
+@router.message(StateFilter('support_admin_reply'), F.from_user.id.in_(get_admins()))
+async def support_admin_reply(message: Message, state: FSM, bot: Bot):
+    data = await state.get_data()
+    user_id = data['reply_to']
+    user_kb = InlineKeyboardBuilder()
+    user_kb.row(ikb('❌ Завершить', data='support_stop'))
+    user_kb.row(ikb('🔙 В меню', data='back_to_menu'))
+    await bot.send_message(
+        user_id,
+        f'Ответ поддержки:\n{message.text}',
+        reply_markup=user_kb.as_markup(),
+    )
+    await message.answer('Отправлено.')
+    await state.clear()
+
+
+@router.callback_query(F.data == 'support_cancel', StateFilter('support_admin_reply'), F.from_user.id.in_(get_admins()))
+async def support_admin_cancel(call: CallbackQuery, state: FSM):
+    await state.clear()
+    await call.message.edit_text('Отменено.')
+    await call.answer()
+
+
+@router.callback_query(F.data == 'support_stop', StateFilter('support_chat'))
+@router.message(F.text == '/stop', StateFilter('support_chat'))
+async def support_stop(event, state: FSM):
+    await state.clear()
+    if isinstance(event, CallbackQuery):
+        await event.message.edit_text('Диалог с поддержкой завершен.', reply_markup=start_menu_finl())
+        await event.answer()
+    else:
+        await event.answer('Диалог с поддержкой завершен.', reply_markup=start_menu_finl())
+
+
+@router.callback_query(F.data.startswith('support_close:'), F.from_user.id.in_(get_admins()))
+async def support_close(call: CallbackQuery, bot: Bot):
+    user_id = int(call.data.split(':')[1])
+    await bot.send_message(user_id, 'Диалог с поддержкой завершен.', reply_markup=start_menu_finl())
+    await call.message.answer('Диалог закрыт.')
+    await call.answer()
+
+
+@router.callback_query(F.data == 'reviews_start')
+async def reviews_start(call: CallbackQuery):
+    kb = InlineKeyboardBuilder()
+    kb.row(ikb('🔙 В меню', data='back_to_menu'))
+    await call.message.edit_text('Отзывы пока отсутствуют.', reply_markup=kb.as_markup())

--- a/tgbot/routers/user/user_menu.py
+++ b/tgbot/routers/user/user_menu.py
@@ -17,22 +17,6 @@ from tgbot.utils.text_functions import open_profile_user
 router = Router(name=__name__)
 
 
-# Открытие товаров
-@router.message(F.text == "🎁 Купить")
-async def user_shop(message: Message, bot: Bot, state: FSM, arSession: ARS):
-    await state.clear()
-
-    get_categories = get_categories_items()
-
-    if len(get_categories) >= 1:
-        await message.answer(
-            "<b>🎁 Выберите нужный вам товар</b>",
-            reply_markup=prod_item_category_swipe_fp(0),
-        )
-    else:
-        await message.answer("<b>🎁 Увы, товары в данное время отсутствуют</b>")
-
-
 # Открытие профиля
 @router.message(F.text == "👤 Профиль")
 async def user_profile(message: Message, bot: Bot, state: FSM, arSession: ARS):


### PR DESCRIPTION
## Summary
- paginate servers in 3-column grid with page indicator and back arrows
- allow navigating back through purchase steps and show Stars pay button directly on invoice
- streamline support routing by sending one inline message per user with reply/close buttons

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6898c862a83c83249370f771187ed055